### PR TITLE
Adding a deparam with regex

### DIFF
--- a/test_urlpy.py
+++ b/test_urlpy.py
@@ -99,6 +99,41 @@ def test_deparam_case_insensitivity():
         good = base + good
         test(bad, good)
 
+def test_r_deparam_sane():
+    def test(bad, good):
+        assert_equal(url.parse(bad).r_deparam(['c']).unicode, good)
+
+    examples = [
+        ('?a=1&b=2&c1=3&d=4', '?a=1&b=2&d=4'),  # Maintains order
+        ('?a=1&&&&&&b=2'   , '?a=1&b=2'),  # Removes excess &'s
+        (';a=1;b=2;c1=3;d=4', ';a=1;b=2;d=4'),  # Maintains order
+        (';a=1;;;;;;b=2'   , ';a=1;b=2'),  # Removes excess ;'s
+        (';foo_c1=2'        , ';foo_c1=2'),  # Not overzealous
+        ('?foo_c1=2'        , '?foo_c1=2'),  # ...
+        ('????foo=2'       , '?foo=2'),  # Removes leading ?'s
+        (';foo'            , ';foo'),
+        ('?foo'            , '?foo'),
+        (''                , '')
+    ]
+    base = 'http://testing.com/page'
+    for bad, good in examples:
+        bad = base + bad
+        good = base + good
+        test(bad, good)
+
+def test_r_deparam_case_insensitivity():
+    def test(bad, good):
+        assert_equal(url.parse(bad).r_deparam(['HeLlO.*']).unicode, good)
+
+    examples = [
+        ('?hELLo_there=2', ''),
+        ('?HELLo_there=2', '')
+    ]
+    base = 'http://testing.com/page'
+    for bad, good in examples:
+        bad = base + bad
+        good = base + good
+        test(bad, good)
 
 def test_filter_params():
     def function(name, value):

--- a/urlpy.py
+++ b/urlpy.py
@@ -237,6 +237,14 @@ class URL(object):
             return name.lower() in lowered
         return self.filter_params(function)
 
+    def r_deparam(self, params):
+        '''Strip any of the provided regex parameters out of the url'''
+        lowered = set([p.lower() for p in params])
+        def function(name, _):
+            regex = '^(' + '|'.join(lowered) + ')$'
+            return bool(re.search(regex, name.lower()))            
+        return self.filter_params(function)
+
     def filter_params(self, function):
         '''Remove parameters if function(name, value)'''
         def keep(query):


### PR DESCRIPTION
Hi there,

I needed to remove regex params like in a single shot without writing a very long list of params:

`__mk_[a-z]{1,3}_[a-z]{1,3}`

So I added a function to do it (`r_depram`) and I thought of sending a pull request.
