### PR TITLE
Remove useless shebang lines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright (c) nexB, Inc.
 # Copyright (c) 2012-2015 SEOmoz, Inc.
 #

--- a/urlpy.py
+++ b/urlpy.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (c) nexB, Inc.
 # Copyright (c) 2012-2015 SEOmoz, Inc.
 #


### PR DESCRIPTION
In addition to not having the executable bit set, `urlpy.py` is an importable module and has no “main routine” or interesting side effects.

While `setup.py` is script-like, it does not have the executable bit set, so the shebang line is not useful.